### PR TITLE
fix: refresh list when dismissing screen

### DIFF
--- a/BoostContacts/ContactDetail/ContactDetailViewController.swift
+++ b/BoostContacts/ContactDetail/ContactDetailViewController.swift
@@ -76,6 +76,7 @@ class ContactDetailViewController: UIViewController {
     // MARK: - Actions
 
     @objc func didTappedCancelButton() {
+        self.presentationController?.delegate?.presentationControllerDidDismiss?(self.presentationController!)
         self.dismiss(animated: true, completion: nil)
     }
 
@@ -86,6 +87,7 @@ class ContactDetailViewController: UIViewController {
     // MARK: - Privates
 
     private func setupUI() {
+        isModalInPresentation = true
         navigationItem.leftBarButtonItem = cancelButton
         navigationItem.rightBarButtonItem = saveButton
         let notificationCenter = NotificationCenter.default
@@ -149,6 +151,7 @@ class ContactDetailViewController: UIViewController {
     }
 
     private func dismissScreen() {
+        self.presentationController?.delegate?.presentationControllerDidDismiss?(self.presentationController!)
         self.dismiss(animated: true, completion: nil)
     }
 }

--- a/BoostContacts/ContactList/ContactListViewController.swift
+++ b/BoostContacts/ContactList/ContactListViewController.swift
@@ -72,6 +72,7 @@ class ContactListViewController: UIViewController {
     @objc func didTappedAddButton() {
         let viewModel = ContactDetailViewModel()
         let controller = ContactDetailViewController(viewModel: viewModel)
+        controller.presentationController?.delegate = self
         let navigation = UINavigationController(rootViewController: controller)
         self.present(navigation, animated: true, completion: nil)
     }
@@ -116,7 +117,14 @@ extension ContactListViewController: UITableViewDelegate {
         let contact = viewModel.contacts[indexPath.row]
         let viewModel = ContactDetailViewModel(contact: contact)
         let controller = ContactDetailViewController(viewModel: viewModel)
+        controller.presentationController?.delegate = self
         let navigation = UINavigationController(rootViewController: controller)
         self.present(navigation, animated: true, completion: nil)
+    }
+}
+
+extension ContactListViewController: UIAdaptivePresentationControllerDelegate {
+    func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+        viewModel.getAllContacts()
     }
 }


### PR DESCRIPTION
This pull request consist of the followings:

- call `viewModel.getAllContacts` on `presentationControllerDidDismiss:`